### PR TITLE
Update NHS digital service manual entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A list of design systems and design resources that gov departments have created.
 - Form builder (lets you create a form transaction visually): https://github.com/DEFRA/digital-form-builder 
 
 ### NHS
-- NHS Design Patterns: https://beta.nhs.uk/service-manual/patterns/
+- NHS digital service manual: https://beta.nhs.uk/service-manual/
 
 ### Office for National Statistics
 - ONS website pattern library: https://onsdigital.github.io/ons-pattern-library-starter/


### PR DESCRIPTION
We (NHS digital service manual team) have recently changed some pages and URLs for our service manual. Corrected the naming of the NHS digital service manual and the URL.

cc: @ctdesign as I cannot request a reviewer.