### PR TITLE
Removal of ESFA services as they fall under DfE

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ A list of design systems and design resources that gov departments have created.
 ### DVSA
 - DVSA Front-end: https://dvsa-front-end.herokuapp.com/
 
-### Education and Skills Funding Agency (ESFA)
-- http://das-design-system.herokuapp.com/
-- http://esfacontent.herokuapp.com/
-
 ### Land Registry
 - Design elements: http://land-registry-elements.herokuapp.com/
 - Design system: https://hmlr-design-system.herokuapp.com/


### PR DESCRIPTION
The ESFA is being merged into DfE and therefore isn't a separate entity. 

Additionally, the design manual isn't applicable as it doesnt contain any specific design patterns or guidance and should be included in the DfE Design manual.

The content guidelines should also be bought into the DfE Manual. 

internally, we're sorting these out. 