### PR TITLE
Add Korean Government Design System

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ A list of design systems and design resources that gov departments have created.
 
 # International
 
+## South Korea
+- Korea Design System(KRDS): https://www.krds.go.kr/
+
 ## Argentina
 - Poncho (in Spanish): https://argob.github.io/poncho/
 


### PR DESCRIPTION
This PR adds the **South Korean Government Design System** to the README.md under the `International` section. 